### PR TITLE
Slim Docker image (CPU torch, multi-stage build)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.27.1
+- Pin `torch` to the CPU-only wheel on linux. `sentence-transformers` pulled `torch` transitively; on linux x86_64 the default PyPI wheel is the CUDA build, dragging in ~4 GB of NVIDIA runtime libraries (cuDNN, cuBLAS, NCCL, cuSparseLt, Triton, …) that never run — the dogfood VM and laptops have no GPU. Two `pyproject.toml` changes: (1) promote `torch` from a transitive to a direct dependency so `[tool.uv.sources]` actually applies to it, (2) declare a CPU-only wheel index scoped to `sys_platform == 'linux'`. macOS is unaffected — its default torch wheel is already CPU-only. `uv lock` diff: `+torch 2.11.0+cpu` on linux; dropped `nvidia-curand`, `nvidia-cusolver`, `nvidia-cusparse`, `nvidia-cusparselt-cu13`, `nvidia-nccl-cu13`, `nvidia-nvjitlink`, `nvidia-nvshmem-cu13`, `nvidia-nvtx`, `triton`. Closes PEA-134 pending a rebuild + size-verification.
+
 ## 1.27.0
 - Drop the unused `playwright` dependency. It was left over from the pre-1.17.5 browser-based Gmail auth path that was deleted when experts moved to OAuth-only; the dep was never removed. No imports reference it anywhere in `pearscarf/` or `experts/`. Removed from `pyproject.toml`; `uv.lock` regenerated (drops `playwright`, `greenlet`, `pyee` — 165 packages total, down from 168). First of two commits slimming the Docker image (closes PEA-123; advances PEA-134 where the bulk of the weight lives — CUDA / torch).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.27.2
+- Multi-stage Docker build. `Dockerfile` now has a `builder` stage on `ghcr.io/astral-sh/uv:python3.12-bookworm-slim` that resolves and installs deps into `/app/.venv`, and a separate runtime stage on `python:3.12-slim-bookworm` that copies only `/app` + `tini`. Drops uv itself, its package cache, and intermediate build layers from the shipped image. Pushed content size: 358 MB → **333 MB** (−25 MB); local disk usage: 1.82 GB → 1.72 GB. Smoke-tested end-to-end: `psc --version`, `sentence_transformers` import, `torch 2.11.0+cpu`, Consumer and `tracked_call` imports all clean.
+
 ## 1.27.1
 - Pin `torch` to the CPU-only wheel on linux. `sentence-transformers` pulled `torch` transitively; on linux x86_64 the default PyPI wheel is the CUDA build, dragging in ~4 GB of NVIDIA runtime libraries (cuDNN, cuBLAS, NCCL, cuSparseLt, Triton, …) that never run — the dogfood VM and laptops have no GPU. Two `pyproject.toml` changes: (1) promote `torch` from a transitive to a direct dependency so `[tool.uv.sources]` actually applies to it, (2) declare a CPU-only wheel index scoped to `sys_platform == 'linux'`. macOS is unaffected — its default torch wheel is already CPU-only. `uv lock` diff: `+torch 2.11.0+cpu` on linux; dropped `nvidia-curand`, `nvidia-cusolver`, `nvidia-cusparse`, `nvidia-cusparselt-cu13`, `nvidia-nccl-cu13`, `nvidia-nvjitlink`, `nvidia-nvshmem-cu13`, `nvidia-nvtx`, `triton`. Closes PEA-134 pending a rebuild + size-verification.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.27.0
+- Drop the unused `playwright` dependency. It was left over from the pre-1.17.5 browser-based Gmail auth path that was deleted when experts moved to OAuth-only; the dep was never removed. No imports reference it anywhere in `pearscarf/` or `experts/`. Removed from `pyproject.toml`; `uv.lock` regenerated (drops `playwright`, `greenlet`, `pyee` — 165 packages total, down from 168). First of two commits slimming the Docker image (closes PEA-123; advances PEA-134 where the bulk of the weight lives — CUDA / torch).
+
 ## 1.26.13
 - Fix `NameError` in `pearscarf/eval/runner.py`: `_pending_record_count` referenced `store.RELEVANT` but the module only imported `graph` from `pearscarf.storage`. Added `store` to the same import. Surfaced while running `psc eval er --dataset …` against a fresh graph.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends tini \
-    && rm -rf /var/lib/apt/lists/*
+# Builder: uv-enabled image for resolving + installing deps and building the project.
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
 
 WORKDIR /app
 
@@ -17,6 +14,18 @@ COPY scripts/ ./scripts/
 COPY README.md CHANGELOG.md ./
 RUN uv sync --frozen --no-dev
 
+
+# Runtime: vanilla Python slim. Copies the built venv + app code from the builder.
+# No uv, no build caches, no dev tooling.
+FROM python:3.12-slim-bookworm
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tini \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /app /app
 COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 

--- a/pearscarf/__init__.py
+++ b/pearscarf/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.27.1"
+__version__ = "1.27.2"
 
 # Make installed expert packages importable from the experts/ folder.
 # Temporary — replaced by the registry-driven discovery in a follow-up.

--- a/pearscarf/__init__.py
+++ b/pearscarf/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.26.13"
+__version__ = "1.27.0"
 
 # Make installed expert packages importable from the experts/ folder.
 # Temporary — replaced by the registry-driven discovery in a follow-up.

--- a/pearscarf/__init__.py
+++ b/pearscarf/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.27.0"
+__version__ = "1.27.1"
 
 # Make installed expert packages importable from the experts/ folder.
 # Temporary — replaced by the registry-driven discovery in a follow-up.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "httpx",
     "langsmith",
     "neo4j",
-    "playwright",
     "psycopg[binary]",
     "psycopg-pool",
     "qdrant-client",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "qdrant-client",
     "python-dotenv",
     "sentence-transformers",
+    "torch",
     "fastmcp",
 ]
 
@@ -40,3 +41,17 @@ path = "pearscarf/__init__.py"
 
 [tool.pyright]
 extraPaths = ["experts"]
+
+# Pin `torch` to the CPU-only wheel on linux. `sentence-transformers` pulls
+# torch transitively; on linux x86_64 its default wheel is the CUDA build,
+# which drags in ~4 GB of nvidia + triton libraries we never run. macOS
+# torch is already CPU-only by default — no override needed there.
+[tool.uv.sources]
+torch = [
+    { index = "pytorch-cpu", marker = "sys_platform == 'linux'" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true


### PR DESCRIPTION
## Summary
- Drop unused `playwright` dep (1.27.0)
- Pin `torch` to the CPU-only linux wheel via `[tool.uv.sources]` + explicit `pytorch-cpu` index (1.27.1)
- Multi-stage `Dockerfile`: `ghcr.io/astral-sh/uv` builder resolves into `/app/.venv`; `python:3.12-slim-bookworm` runtime copies only `/app` + `tini` (1.27.2)

Net: pushed image 3.09 GB → 333 MB; local disk 8.58 GB → 1.72 GB. CUDA stack (nvidia/*, triton) eliminated.

## Test plan
- [x] `psc --version` clean in the slim image
- [x] `from sentence_transformers import SentenceTransformer` imports
- [x] `torch.__version__ == "2.11.0+cpu"`, `torch.cuda.is_available() == False`
- [x] ER eval against fresh graph: 6/6 expected entities, Qdrant 4 points on green collection