### PR TITLE
Codify first-line-is-title intent convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.39.2
+- Intent format spec (`pearscarf://format/intent`) codifies the first-line-is-title convention. Authors are now told to lead the body with a single-sentence, ≤120-char actionable title — the line that surfaces in dashboards and list views — with the agent's pickup brief continuing below. No schema change; the discipline is purely in the author's prose. Dashboards (pearscarf-ui) extract this line as the displayed title.
+
 ## 1.39.1
 - Add `runtime` (TEXT) and `runtime_config` (JSONB) fields to `intent_details` — the runtime envelope that decouples the orchestrator from any specific agent stack.
 - `runtime` selects which orchestrator adapter dispatches the intent (default `"claude"`; orchestrator-side registry can add `"codex"`, `"hermes"`, etc.); `runtime_config` is an opaque JSON object the adapter consumes (for `"claude"`: e.g. `chrome_required`, `mcp_servers`, `model`, `prompt_role`).

--- a/pearscarf/__init__.py
+++ b/pearscarf/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.39.1"
+__version__ = "1.39.2"
 __url__ = "https://github.com/pearshape-ai/pearscarf"
 
 __all__ = ["__version__", "__url__"]

--- a/pearscarf/knowledge/intents/format.md
+++ b/pearscarf/knowledge/intents/format.md
@@ -18,9 +18,13 @@ Two non-negotiable rules apply to every intent:
 
 The body is plain markdown prose. There is no required header structure — intents are not parsed for fields. The discipline is in the prose itself.
 
+### Title convention
+
+**The first non-empty line of the body is the intent's title.** Keep it short (≤ 120 chars), single-sentence, actionable — it's what surfaces in dashboards, list views, and any operator scan over open work. Write it like a commit header: the change in one clean phrase. Everything below the title line is the agent's pickup brief; agents read the whole body (including the title line) as their task. No artificial section headers are required between title and body.
+
 A well-formed intent body addresses, in this order:
 
-- **What** — the intended outcome in one or two sentences. Lead with this.
+- **What (title line)** — the intended outcome in one sentence. This is the first non-empty line and becomes the surfaced title.
 - **Who** — the role or agent owning the work. Omit for containers (intents that exist only to group sub-intents).
 - **Why** — one sentence on motivation. Skip if the parent intent makes it obvious.
 - **Acceptance** — the observable reality fact that means done. Phrase it as something an outside reader could verify after the work lands.


### PR DESCRIPTION
Tiny doc-only patch (1.39.2). Adds the title-convention section to the intent format spec at `pearscarf://format/intent`. No code or schema changes.

Pearscarf-ui already consumes this convention in 0.5.0 (extracts the first non-empty line as the displayed title, with backward-compat for legacy `#` / `Goal:` / `Title:` etc. prefixes).