### PR TITLE
Bearer-token auth on MCP (1.40.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.40.0
+- MCP server now enforces Bearer-token auth against the `mcp_keys` Postgres table. Every request to a tool route must carry `Authorization: Bearer <raw-key>` matching a non-revoked row; invalid or missing tokens are rejected (401) before any tool runs. The `/health` route is exempt (declared via `@mcp.custom_route`, which sits outside the MCP transport's middleware chain). Implemented as a `fastmcp.server.auth.auth.AuthProvider` (`pearscarf/mcp/auth.py`) that delegates to a new `verify_mcp_key(raw)` helper in `pearscarf.storage.store` — returns the row (id + name) on a match so the request can be attributed to a specific key for audit. The verifier pulls all non-revoked hashes and compares with `hmac.compare_digest` (constant-time) rather than `WHERE key_hash = %s` (which short-circuits on first-byte mismatch); the loop also intentionally doesn't `break` on a match, so total runtime doesn't leak which row matched. Successful validation updates `last_used_at`. Operator workflow stays as before: `psc mcp-keys create <device>` to issue, `psc mcp-keys list` to inspect, `psc mcp-keys revoke <id>` to retire.
+
 ## 1.39.2
 - Intent format spec (`pearscarf://format/intent`) codifies the first-line-is-title convention. Authors are now told to lead the body with a single-sentence, ≤120-char actionable title — the line that surfaces in dashboards and list views — with the agent's pickup brief continuing below. No schema change; the discipline is purely in the author's prose. Dashboards (pearscarf-ui) extract this line as the displayed title.
 

--- a/pearscarf/__init__.py
+++ b/pearscarf/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.39.2"
+__version__ = "1.40.0"
 __url__ = "https://github.com/pearshape-ai/pearscarf"
 
 __all__ = ["__version__", "__url__"]

--- a/pearscarf/mcp/auth.py
+++ b/pearscarf/mcp/auth.py
@@ -1,0 +1,37 @@
+"""FastMCP AuthProvider that verifies incoming `Authorization: Bearer <key>`
+headers against pearscarf's `mcp_keys` Postgres table.
+
+When this provider is installed on the FastMCP server, every MCP-routed
+request must carry a Bearer token that matches a non-revoked row in
+`mcp_keys`. Mismatched or missing tokens are rejected (401) before any
+tool runs. Successful verifications update the key's `last_used_at`.
+
+Bootstrap order (operator responsibility, not enforced in code):
+1. `psc mcp-keys create <device>` to issue at least one key.
+2. Restart the MCP server (or deploy a new image that installs this
+   provider). Any client that wants to call MCP tools must send the
+   raw key as `Authorization: Bearer <key>`.
+
+`@mcp.custom_route` endpoints (e.g. `/health`) bypass this middleware —
+FastMCP only wires auth into the MCP transport routes (`/mcp`, `/sse`).
+"""
+
+from __future__ import annotations
+
+from fastmcp.server.auth.auth import AccessToken, AuthProvider
+
+from pearscarf.storage.store import verify_mcp_key
+
+
+class PearscarfAuthProvider(AuthProvider):
+    """Bearer-token auth against the `mcp_keys` table."""
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        if not token:
+            return None
+        row = verify_mcp_key(token)
+        if row is None:
+            return None
+        # client_id is the key's human-readable name — surfaces in audit /
+        # logging downstream.
+        return AccessToken(token=token, client_id=row["name"], scopes=[])

--- a/pearscarf/mcp/mcp_server.py
+++ b/pearscarf/mcp/mcp_server.py
@@ -31,11 +31,17 @@ from datetime import datetime
 from fastmcp import FastMCP
 
 from pearscarf.config import MCP_HOST, MCP_HTTP_PORT, MCP_PORT
+from pearscarf.mcp.auth import PearscarfAuthProvider
 from pearscarf.query import context_query
 from pearscarf.storage import graph, vectorstore
 from pearscarf.storage.db import _get_conn, init_db
 
-mcp = FastMCP("PearScarf")
+# Bearer-token auth against the `mcp_keys` table. Without a valid Bearer
+# header, FastMCP returns 401 before any tool runs. Issue keys with
+# `psc mcp-keys create <device>`; revoke with `psc mcp-keys revoke <id>`.
+# The /health route declared with `@mcp.custom_route` bypasses this
+# middleware.
+mcp = FastMCP("PearScarf", auth=PearscarfAuthProvider())
 
 
 # ---------------------------------------------------------------------------

--- a/pearscarf/storage/store.py
+++ b/pearscarf/storage/store.py
@@ -528,6 +528,7 @@ def get_communications_for_entity(name_or_email: str, since: str | None = None) 
 # --- MCP Keys ---
 
 import hashlib  # noqa: E402
+import hmac  # noqa: E402
 import secrets  # noqa: E402
 
 
@@ -579,22 +580,61 @@ def revoke_mcp_key(key_id: str) -> bool:
 
 
 def validate_mcp_key(raw_key: str) -> bool:
-    """Validate an MCP key. Updates last_used_at if valid."""
+    """Validate an MCP key. Updates last_used_at if valid.
+
+    Kept for callers that only need a bool. New auth code paths should
+    prefer `verify_mcp_key()` so they can attribute the request to a
+    specific key (id + name) for logging.
+    """
+    return verify_mcp_key(raw_key) is not None
+
+
+def verify_mcp_key(raw_key: str) -> dict | None:
+    """Verify an MCP key and return its row (id, name) if valid, else None.
+
+    Pulls all non-revoked hashes and compares in Python with
+    `hmac.compare_digest` rather than relying on SQL `WHERE key_hash = %s`
+    (which short-circuits on first-byte mismatch). The comparison cost is
+    O(N) over non-revoked keys per request — fine at our scale (handful
+    of keys); if the table ever grew large we'd partition by a prefix
+    indicator so each request compared a small bucket.
+
+    Updates `last_used_at` on success.
+    """
     init_db()
-    key_hash = _hash_key(raw_key)
+    if not raw_key:
+        return None
+    candidate_hash = _hash_key(raw_key)
     with _get_conn() as conn:
-        row = conn.execute(
-            "SELECT id FROM mcp_keys WHERE key_hash = %s AND revoked = FALSE",
-            (key_hash,),
-        ).fetchone()
-        if not row:
-            return False
+        rows = conn.execute(
+            "SELECT id, name, key_hash FROM mcp_keys WHERE revoked = FALSE"
+        ).fetchall()
+        matched: dict | None = None
+        for row in rows:
+            if hmac.compare_digest(candidate_hash, row["key_hash"]):
+                matched = {"id": row["id"], "name": row["name"]}
+                # Don't break — keep iterating so the loop's runtime
+                # doesn't leak which row matched.
+        if matched is None:
+            return None
         conn.execute(
             "UPDATE mcp_keys SET last_used_at = now() WHERE id = %s",
-            (row["id"],),
+            (matched["id"],),
         )
         conn.commit()
-        return True
+        return matched
+
+
+def mcp_keys_exist() -> bool:
+    """Return True iff at least one non-revoked MCP key exists. Used by the
+    MCP server to fail closed when keys are configured but to keep the
+    server reachable in fresh-deploy / single-operator setups where no key
+    has been created yet (a `psc mcp-keys list` after-the-fact surfaces the
+    state)."""
+    init_db()
+    with _get_conn() as conn:
+        row = conn.execute("SELECT 1 FROM mcp_keys WHERE revoked = FALSE LIMIT 1").fetchone()
+        return row is not None
 
 
 # --- Expert registration ---


### PR DESCRIPTION
## Summary

MCP server now enforces `Authorization: Bearer <raw-key>` on every tool route.

- `pearscarf/storage/store.py` — new `verify_mcp_key(raw)` returns `{id, name}` on a match. Pulls all non-revoked hashes, compares with `hmac.compare_digest` (constant-time). Loop intentionally doesn't `break` on match — runtime is constant regardless of which row matched.
- `pearscarf/mcp/auth.py` (new) — `PearscarfAuthProvider(AuthProvider)`. Builds `AccessToken` with `client_id=<key name>` for downstream audit.
- `pearscarf/mcp/mcp_server.py` — `mcp = FastMCP("PearScarf", auth=PearscarfAuthProvider())`. `/health` (custom_route) bypasses auth.

Operator flow: `psc mcp-keys create <device>` issues, `list` inspects, `revoke <id>` retires.

## Test plan

Local smoke test against dogfood DB (Postgres + Neo4j IAP tunnels) — four cases:

- [x] `GET /health` → 200 (bypassed)
- [x] `POST /mcp` no `Authorization` → 401
- [x] `POST /mcp` wrong Bearer → 401
- [x] `POST /mcp` valid Bearer → 200 + valid initialize

Type checks + ruff: passing.