### PR TITLE
Align MCP tests with 1.40.x behavior (1.40.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.40.2
+- Test maintenance. Align the MCP-server tests with the 1.40.1 single-transport shape (the dual `_sse_thread`/`_http_thread` asserts now check only the surviving `_http_thread`) and update `test_validate_mcp_key_returns_true_and_updates_last_used` to feed the constant-time verifier's `fetchall` path with a row whose `key_hash` matches `sha256(raw_key)`. No behavior change.
+
 ## 1.40.1
 - Retire the SSE transport. The MCP server now serves only streamable-HTTP on `MCP_PORT` (default 8091). `MCPServer._run_sse` and `MCPServer._sse_thread` removed; `run_foreground` runs the single transport blocking. `MCP_HTTP_PORT` env var removed (its old role is folded into `MCP_PORT`). The SSE endpoint at `/sse` was session-coupled to the streaming connection — when the connection blipped, the session ID became invalid and every subsequent tool call failed with "Could not find session". Streamable-HTTP at `/mcp` has no such coupling. Bearer-token auth (introduced in 1.40.0) keeps working unchanged on the surviving transport.
 

--- a/pearscarf/__init__.py
+++ b/pearscarf/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.40.1"
+__version__ = "1.40.2"
 __url__ = "https://github.com/pearshape-ai/pearscarf"
 
 __all__ = ["__version__", "__url__"]

--- a/tests/unit/mcp/test_mcp_server.py
+++ b/tests/unit/mcp/test_mcp_server.py
@@ -276,26 +276,21 @@ def test_get_record_status_stage_mapping(
     assert out["stage"] == expected_stage
 
 
-# ---- MCPServer dual-transport ----
+# ---- MCPServer single-transport (streamable-HTTP only since 1.40.1) ----
 
 
-def test_mcp_server_dual_transport_instantiates() -> None:
+def test_mcp_server_instantiates() -> None:
     server = mcp_server.MCPServer()
-    assert server._sse_thread is None
     assert server._http_thread is None
 
 
-def test_mcp_server_start_launches_both_threads(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_mcp_server_start_launches_http_thread(monkeypatch: pytest.MonkeyPatch) -> None:
     # Mock init_db and mcp.run so they don't actually block
     monkeypatch.setattr("pearscarf.mcp.mcp_server.init_db", lambda: None)
     monkeypatch.setattr("pearscarf.mcp.mcp_server.mcp.run", lambda **kw: None)
 
     server = mcp_server.MCPServer()
     server.start()
-
-    assert server._sse_thread is not None
-    assert server._sse_thread.name == "mcp-server-sse"
-    assert server._sse_thread.daemon is True
 
     assert server._http_thread is not None
     assert server._http_thread.name == "mcp-server-http"

--- a/tests/unit/storage/test_store.py
+++ b/tests/unit/storage/test_store.py
@@ -146,8 +146,17 @@ def test_validate_mcp_key_returns_false_when_unknown(patched_store_conn: MagicMo
 def test_validate_mcp_key_returns_true_and_updates_last_used(
     patched_store_conn: MagicMock,
 ) -> None:
-    _set_fetchone(patched_store_conn, {"id": "mck_001"})
-    assert store.validate_mcp_key("psk_anything") is True
+    # Since 1.40.0 the verifier pulls all non-revoked rows and compares
+    # hashes in constant time, so the mock needs to feed `fetchall` (not
+    # `fetchone`) a row whose `key_hash` matches `sha256(raw_key)`.
+    import hashlib
+
+    raw = "psk_anything"
+    matching_hash = hashlib.sha256(raw.encode()).hexdigest()
+    patched_store_conn.execute.return_value.fetchall.return_value = [
+        {"id": "mck_001", "name": "test", "key_hash": matching_hash}
+    ]
+    assert store.validate_mcp_key(raw) is True
     update_calls = [
         c for c in patched_store_conn.execute.call_args_list if "last_used_at" in c.args[0]
     ]


### PR DESCRIPTION
Three stale asserts from yesterday's 1.40.0 + 1.40.1 PRs caught failing. No behavior change, just tests catching up:

- `test_mcp_server_dual_transport_instantiates` + `test_mcp_server_start_launches_both_threads` referenced `_sse_thread` — removed in 1.40.1. Renamed + asserts check only `_http_thread`.
- `test_validate_mcp_key_returns_true_and_updates_last_used` fed `fetchone` a single row — the 1.40.0 constant-time verifier iterates `fetchall` and compares `hmac.compare_digest` on each row's `key_hash`. Mock now hashes `raw_key` with sha256 and feeds the matching row through `fetchall`.

Full suite: 317 passed, 44 skipped, 0 failed.